### PR TITLE
fix: enhance WebGPU error handling and retry logic for background rem…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 saveExact: true
 autoInstallPeers: false
+strictPeerDependencies: true
 minimumReleaseAge: 1440
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeStrict: true

--- a/src/lib/remove-background.test.ts
+++ b/src/lib/remove-background.test.ts
@@ -94,6 +94,56 @@ describe("model runtime configuration", () => {
 		expect(progress).toHaveBeenCalledWith(0.75, "Downloading model");
 	});
 
+	it("retries automatic model preloading on CPU when WebGPU cannot initialize", async () => {
+		const progress = vi.fn();
+		backgroundRemovalMocks.preload.mockRejectedValueOnce(new Error("no available backend found. ERR: [webgpu] webgpuInit is not a function")).mockResolvedValueOnce(undefined);
+
+		await expect(preloadBackgroundModel({ device: "auto", model: "isnet_quint8", onProgress: progress })).resolves.toBeUndefined();
+
+		expect(backgroundRemovalMocks.preload).toHaveBeenCalledTimes(2);
+		expect(backgroundRemovalMocks.preload.mock.calls[0]?.[0]).toMatchObject({ device: "gpu" });
+		expect(backgroundRemovalMocks.preload.mock.calls[1]?.[0]).toMatchObject({ device: "cpu" });
+		expect(progress).toHaveBeenCalledWith(0, "WebGPU unavailable; retrying with CPU");
+	});
+
+	it("retries automatic removal on CPU when WebGPU cannot initialize", async () => {
+		const cutout = new Blob(["cutout"], { type: "image/png" });
+		const progress = vi.fn();
+		backgroundRemovalMocks.removeBackground
+			.mockRejectedValueOnce(new Error("no available backend found. ERR: [webgpu] webgpuInit is not a function"))
+			.mockResolvedValueOnce(cutout);
+
+		await expect(
+			removeImageBackground(new Blob(["source"]), {
+				algorithm: "natural",
+				device: "auto",
+				model: "isnet_fp16",
+				onProgress: progress,
+			}),
+		).resolves.toBe(cutout);
+
+		expect(backgroundRemovalMocks.removeBackground).toHaveBeenCalledTimes(2);
+		expect(backgroundRemovalMocks.removeBackground.mock.calls[0]?.[1]).toMatchObject({ device: "gpu" });
+		expect(backgroundRemovalMocks.removeBackground.mock.calls[1]?.[1]).toMatchObject({ device: "cpu" });
+		expect(progress).toHaveBeenCalledWith(0, "WebGPU unavailable; retrying with CPU");
+	});
+
+	it("does not override an explicitly selected WebGPU device", async () => {
+		const backendError = new Error("[webgpu] adapter initialization failed");
+		backgroundRemovalMocks.removeBackground.mockRejectedValue(backendError);
+
+		await expect(removeImageBackground(new Blob(["source"]), { algorithm: "natural", device: "gpu", model: "isnet" })).rejects.toBe(backendError);
+		expect(backgroundRemovalMocks.removeBackground).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not mask unrelated errors while using automatic device selection", async () => {
+		const downloadError = new Error("Model download failed");
+		backgroundRemovalMocks.removeBackground.mockRejectedValue(downloadError);
+
+		await expect(removeImageBackground(new Blob(["source"]), { algorithm: "natural", device: "auto", model: "isnet" })).rejects.toBe(downloadError);
+		expect(backgroundRemovalMocks.removeBackground).toHaveBeenCalledTimes(1);
+	});
+
 	it("handles progress events without totals", async () => {
 		const progress = vi.fn();
 		backgroundRemovalMocks.preload.mockImplementation(async (...args: unknown[]) => {

--- a/src/lib/remove-background.ts
+++ b/src/lib/remove-background.ts
@@ -20,6 +20,15 @@ const runtimeConfig = (options: Pick<RemoveOptions, "model" | "device">) => {
 	};
 };
 
+const isWebGpuBackendError = (error: unknown): boolean => {
+	const message = error instanceof Error ? `${error.message} ${String(error.cause ?? "")}` : String(error);
+	return /webgpu|no available backend/i.test(message);
+};
+
+const shouldRetryWithCpu = (device: ProcessingDevice, error: unknown): boolean => {
+	return device === "auto" && isWebGpuBackendError(error);
+};
+
 const encodePng = async (canvas: HTMLCanvasElement): Promise<Blob> => {
 	return new Promise((resolve, reject) => {
 		canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Could not encode refined cutout"))), "image/png");
@@ -99,13 +108,23 @@ const applyMatteAlgorithm = async (blob: Blob, algorithm: MatteAlgorithm): Promi
 
 export const preloadBackgroundModel = async (options: PreloadOptions): Promise<void> => {
 	const { preload } = await import("@imgly/background-removal");
-	await preload({
-		...runtimeConfig(options),
-		progress: (key: string, current: number, total: number) => {
-			const fraction = total > 0 ? Math.min(1, current / total) : 0;
-			options.onProgress?.(fraction, describe(key));
-		},
-	});
+	const runPreload = async (device: ProcessingDevice): Promise<void> => {
+		await preload({
+			...runtimeConfig({ ...options, device }),
+			progress: (key: string, current: number, total: number) => {
+				const fraction = total > 0 ? Math.min(1, current / total) : 0;
+				options.onProgress?.(fraction, describe(key));
+			},
+		});
+	};
+
+	try {
+		await runPreload(options.device);
+	} catch (error) {
+		if (!shouldRetryWithCpu(options.device, error)) throw error;
+		options.onProgress?.(0, "WebGPU unavailable; retrying with CPU");
+		await runPreload("cpu");
+	}
 };
 
 /**
@@ -114,14 +133,24 @@ export const preloadBackgroundModel = async (options: PreloadOptions): Promise<v
  */
 export const removeImageBackground = async (file: File | Blob, options: RemoveOptions): Promise<Blob> => {
 	const { removeBackground } = await import("@imgly/background-removal");
+	const runRemoval = async (device: ProcessingDevice): Promise<Blob> => {
+		return removeBackground(file, {
+			...runtimeConfig({ ...options, device }),
+			progress: (key: string, current: number, total: number) => {
+				const fraction = total > 0 ? Math.min(0.9, (current / total) * 0.9) : 0;
+				options.onProgress?.(fraction, describe(key));
+			},
+		});
+	};
 
-	const cutout = await removeBackground(file, {
-		...runtimeConfig(options),
-		progress: (key: string, current: number, total: number) => {
-			const fraction = total > 0 ? Math.min(0.9, (current / total) * 0.9) : 0;
-			options.onProgress?.(fraction, describe(key));
-		},
-	});
+	let cutout: Blob;
+	try {
+		cutout = await runRemoval(options.device);
+	} catch (error) {
+		if (!shouldRetryWithCpu(options.device, error)) throw error;
+		options.onProgress?.(0, "WebGPU unavailable; retrying with CPU");
+		cutout = await runRemoval("cpu");
+	}
 
 	options.onProgress?.(0.94, options.algorithm === "natural" ? "Finalizing cutout" : "Refining edges");
 	const refined = await applyMatteAlgorithm(cutout, options.algorithm);

--- a/tests/security-baseline.test.ts
+++ b/tests/security-baseline.test.ts
@@ -76,12 +76,24 @@ describe("repository automation security", () => {
 
 	it("keeps package installation supply-chain policies enabled", () => {
 		const pnpmPolicy = readRepositoryFile("pnpm-workspace.yaml");
+		expect(pnpmPolicy).toMatch(/^strictPeerDependencies:\s*true$/m);
 		expect(pnpmPolicy).toMatch(/^minimumReleaseAge:\s*1440$/m);
 		expect(pnpmPolicy).toMatch(/^minimumReleaseAgeStrict:\s*true$/m);
 		expect(pnpmPolicy).toMatch(/^minimumReleaseAgeIgnoreMissingTime:\s*false$/m);
 		expect(pnpmPolicy).toMatch(/^trustPolicy:\s*no-downgrade$/m);
 		expect(pnpmPolicy).toMatch(/^trustLockfile:\s*false$/m);
 		expect(pnpmPolicy).toMatch(/^blockExoticSubdeps:\s*true$/m);
+	});
+
+	it("keeps ONNX Runtime aligned with the background-removal peer dependency", () => {
+		const applicationPackage = JSON.parse(readRepositoryFile("package.json")) as {
+			dependencies: Record<string, string>;
+		};
+		const backgroundRemovalPackage = JSON.parse(readRepositoryFile("node_modules", "@imgly", "background-removal", "package.json")) as {
+			peerDependencies: Record<string, string>;
+		};
+
+		expect(applicationPackage.dependencies["onnxruntime-web"]).toBe(backgroundRemovalPackage.peerDependencies["onnxruntime-web"]);
 	});
 
 	it("requires human accountability and security checks for AI-assisted changes", () => {


### PR DESCRIPTION
…oval

## Summary

<!-- Explain what changed and why. Focus on the user or developer problem being solved. -->

## Related issue

<!-- Use "Closes #123" when this pull request should close an issue after merging. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] User interface or accessibility improvement
- [ ] Performance or processing improvement
- [ ] Documentation
- [ ] Refactor or maintenance

## How was this tested?

<!-- List exact commands and manual scenarios. Include browser/device coverage when relevant. -->

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test:coverage`
- [ ] `pnpm build`

Manual checks:

-

## Visual changes

<!-- Add screenshots or recordings for UI changes. Show both light and dark themes when colors or interactions changed. Write "Not applicable" otherwise. -->

## Privacy, performance, and network impact

<!-- Describe new requests, model assets, storage, analytics, or performance costs. Write "None" when there is no impact. -->

## AI assistance

<!-- Write "None" or name the tool, what it generated or changed, and how you independently verified it. Read AI_CONTRIBUTIONS.md before submitting material AI-assisted work. -->

## Contributor checklist

- [ ] I kept this pull request focused and reviewed my own changes.
- [ ] I disclosed material AI assistance and remain accountable for every submitted line, dependency, asset, test, and claim.
- [ ] I linked or explained the related issue and updated documentation where needed.
- [ ] I preserved on-device image processing and did not introduce an undisclosed upload or network request.
- [ ] I tested affected interactions with keyboard navigation and appropriate assistive semantics.
- [ ] I checked affected UI in light and dark themes and at mobile and desktop widths.
- [ ] I used `const` arrow functions for named functions and placed shared declarations under `src/types`.
- [ ] I added `cursor-pointer` to newly interactive elements where appropriate.
- [ ] I verified new package names, upstream sources, licenses, and generated-code provenance rather than trusting an AI suggestion.
- [ ] I understand that my contribution is submitted under the repository's AGPL-3.0-only license.
